### PR TITLE
yo xp tweak + xptop reaction-based navigation fix

### DIFF
--- a/cogs/handlers/messageEvents.py
+++ b/cogs/handlers/messageEvents.py
@@ -39,12 +39,15 @@ class messageEvents(commands.Cog):
 #### MAIN HANDLERS #####
 
 async def yoSystem_Handler(message):
-        yo_variations = ["yo", "Yo!", "yoy", "yoyo","<:YO:714280062437818559>","oy","<:yonas:741360791667605596>", "<:YoBoss:787408970792697876>", "<:SquidYo:714937825518157905>","<:shellyo:741359253050097674>"]
-
-        #check if message contains words in
         content = message.content.lower()
+        yo_variations = ["yo", "Yo!", "yoy", "yoyo","<:YO:714280062437818559>","oy","<:yonas:741360791667605596>", "<:YoBoss:787408970792697876>", "<:SquidYo:714937825518157905>","<:shellyo:741359253050097674>"]
+        words = content.split()
+
         if any(variation in content for variation in yo_variations):
-            yoCollection.find_one_and_update({"word":"yo"}, {"$inc":{"yo": 1}})
+            yoCollection.find_one_and_update({"word": "yo"}, {"$inc": {"yo": 1}})
+            return True
+
+        return False
 
 async def QuickOrFeedbackCommands(message):
 # Extract the command name and arguments

--- a/cogs/xp/XpCommands.py
+++ b/cogs/xp/XpCommands.py
@@ -201,11 +201,8 @@ class XpCommand(commands.Cog):
 
             message = await ctx.send(embed=await generate_embed(current_page))
 
-            buttons = [
-                "<:left:1286702311661375519>",
-                "<:right:1286702326274592788>",
-            ]
-
+            buttons = ["<:left:1286702311661375519>", "<:right:1286702326274592788>"]
+        
             for button in buttons:
                 await message.add_reaction(button)
 
@@ -219,15 +216,14 @@ class XpCommand(commands.Cog):
             while True:
                 try:
                     reaction, user = await self.bot.wait_for("reaction_add", check=check, timeout=30)
+                    if str(reaction.emoji) == "<:left:1286702311661375519>" and page_num > 1:
+                        page_num -= 1
+                    elif str(reaction.emoji) == "<:right:1286702326274592788>" and page_num < total_pages:
+                        page_num += 1
 
-                    if str(reaction.emoji) == "<:left:1286702311661375519>" and current_page > 0:
-                        current_page -= 1
-                    elif str(reaction.emoji) == "<:right:1286702326274592788>" and current_page < total_pages - 1:
-                        current_page += 1
-
-                    await message.edit(embed= await generate_embed(current_page))
+                    embed = await generate_embed(page_num)
+                    await message.edit(embed=embed)
                     await message.remove_reaction(reaction, user)
-
                 except asyncio.TimeoutError:
                     break
 
@@ -268,8 +264,9 @@ class XpCommand(commands.Cog):
             return
         
         self.user_cooldowns[message.author.id] = time.time() + 60
-        # MAYBE: Check for yo and only give 1 xp? idk, we'll see.
-        added_xp = random.randint(self.min_xp, self.max_xp)
+        # check if the message is a 'yo'
+        yo_message = await yoSystem_Handler(message)
+        added_xp = 1 if yo_message else random.randint(self.min_xp, self.max_xp)
         await self.add_xp(message.author, added_xp)
 
     async def add_xp(self, user: discord.Member,  xp: int, force_give_roles: bool = False ):


### PR DESCRIPTION
so like i was talking with sig and sig told me that the "yo = 1xp" thing was never implemented in this version so i did it AND fixed words like "you" counting as yos
also !xptop's reaction thing was broken for a while now and i think the commit i made somehow fixes the issue (it does for my squidbot clone)