### PR TITLE
Fix inconsistency between add and delete quick commands

### DIFF
--- a/cogs/admin/quickcommands.py
+++ b/cogs/admin/quickcommands.py
@@ -22,7 +22,7 @@ class QuickCommands(commands.Cog):
                       usage="sq!dqc commandName")
     @commands.has_role(AIRole)
     async def deletequickcommand(self, ctx:commands.Context, command_name):
-        result = collection.find_one_and_delete({"commandName": command_name.lower()})
+        result = collection.find_one_and_delete({"commandName": command_name})
 
         if result is None:
             await ctx.send(f"The quick command you are trying to delete doesn't exist!")


### PR DESCRIPTION
support for non-lowercase quick commands improvement (remove .lower() at deletequickcommand such that capitalized quick commands are deletable)